### PR TITLE
fix Polish Sage book: author names, accents

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -4358,8 +4358,8 @@ archivePrefix = "arXiv",
 }
 
 @book{polishSageBook,
-  author = {Theobald, Thorsten and Iliman, Sadik},
-  title = {Zrozumie\c{c} matematyk\c{e} z pakietem Sage ("Understand mathematics with the Sage package")},
+  author = {Giniewicz, Andrzej and Zaj\k{a}czkowska, Katarzyna},
+  title = {Zrozumie\'{c} matematyk\k{e} z pakietem Sage ("Understand mathematics with the Sage package")},
   publisher = {GiS},
   year = {2016},
   url = {http://www.eurekacode.com/matematyka}


### PR DESCRIPTION
Fix author names and accented characters in title of Polish Sage book.