### PR TITLE
Fix latex accent in Thiéry

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -4485,7 +4485,7 @@ archivePrefix = "arXiv",
 
 @unpublished{DehKohKon:iop16,
   title = {Interoperability in the {OpenDreamKit} Project: The Math-in-the-Middle Approach},
-  author = {Paul-Olivier Dehaye and Michael Kohlhase and Alexander Konovalov and Samuel Leli{\`e}vre and Markus Pfeiffer and Nicolas M. Thi{\́e}ry},
+  author = {Paul-Olivier Dehaye and Michael Kohlhase and Alexander Konovalov and Samuel Leli{\`e}vre and Markus Pfeiffer and Nicolas M. Thi{\'e}ry},
   url = {http://arxiv.org/abs/1603.06424},
   pubs = {mkohlhase},
   crossref = {CICM16},


### PR DESCRIPTION
Fix {\́e} -> {\'e}.