### PR TITLE
Add publication based on Galois complexity

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -4686,7 +4686,7 @@ archivePrefix = "arXiv",
    volume = {19},
    number = {2},
    pages = {619--656},
-   doi = {10.7155/jgaa.00349}
+   doi = {10.7155/jgaa.00349},
    url={http://dx.doi.org/10.7155/jgaa.00349}
 }
 

--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -4677,3 +4677,26 @@ archivePrefix = "arXiv",
     type = "Master's Thesis",
     url = "http://www.sagemath.org/files/kertels-thesis-2016.pdf"
 }
+
+@Article{JGAA-349,
+   author = {{Michael} J. {Bannister} and {William} E. {Devanny} and {David} {Eppstein} and {Michael} T. {Goodrich}},
+   title = {The Galois Complexity of Graph Drawing: Why Numerical Solutions are Ubiquitous for Force-Directed, Spectral, and Circle Packing Drawings},
+   journal = {Journal of Graph Algorithms and Applications},
+   year = {2015},
+   volume = {19},
+   number = {2},
+   pages = {619--656},
+   doi = {10.7155/jgaa.00349}
+   url={http://dx.doi.org/10.7155/jgaa.00349}
+}
+
+@inproceedings{BanDevEpp-GD-14,
+  title = {{The Galois complexity of graph drawing}},
+  address = {Berlin, Heidelberg},
+  author = {Michael J. Bannister and William E. Devanny and David Eppstein and Michael T. Goodrich},
+  booktitle = {Proceedings of the 22nd International Symposium on Graph Drawing (GD'14)},
+  eprint = {1408.1422},
+  publisher = {Springer-Verlag},
+  pages={149--161},
+  url={http://dx.doi.org/10.1007/978-3-662-45803-7_13},
+  year = {2014}}


### PR DESCRIPTION
The publications I have added used SageMath for the calculation of Galois Groups and for the simplification of systems of polynomials.