### PR TITLE
Add reference for Hulse and others, 2017

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -2563,6 +2563,19 @@ note = {http://arxiv.org/abs/1004.4886},
        URL = {http://doi.org/10.1016/j.jnt.2017.01.007},
 }
 
+@article{Hutz2016,
+    author = {Benjamin Hutz},
+    title = {Sage as a Source for Undergraduate Research Projects},
+    journal = {PRIMUS},
+    volume = {0},
+    number = {0},
+    pages = {1-14},
+    year = {0},
+    doi = {10.1080/10511970.2016.1192072},
+    URL = {http://dx.doi.org/10.1080/10511970.2016.1192072},
+    eprint = {http://dx.doi.org/10.1080/10511970.2016.1192072},
+}
+
 @article{Ingram2009,
   author = {Patrick Ingram},
   title = {Multiples of Integral Points on Elliptic Curves},
@@ -4511,6 +4524,17 @@ $p=2$.},
   url={http://joshua.smcvt.edu/linearalgebra/},
   year={2014},
   publisher={CC BY-SA 2.5 self-published}
+}
+
+@article{hefferon2016,
+  title={Writing an Open Text},
+  author={Hefferon, Jim and Schueller, Albert},
+  journal={The Mathematical Intelligencer},
+  volume={38},
+  number={2},
+  pages={6--9},
+  year={2016},
+  publisher={Springer}
 }
 
 @book {WagstaffJoyFactoring,

--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -2549,6 +2549,20 @@ note = {http://arxiv.org/abs/1004.4886},
   note = {http://arxiv.org/abs/0904.1141},
 }
 
+@article{HulseEtAl2017,
+    AUTHOR = {Hulse, Thomas A. and Kuan, Chan Ieong and Lowry-Duda, David
+              and Walker, Alexander},
+     TITLE = {Sign changes of coefficients and sums of coefficients of {L}-functions},
+   JOURNAL = {J. Number Theory},
+  FJOURNAL = {Journal of Number Theory},
+    VOLUME = {177},
+      YEAR = {2017},
+     PAGES = {112--135},
+   MRCLASS = {11F30 (11F03)},
+       DOI = {10.1016/j.jnt.2017.01.007},
+       URL = {http://doi.org/10.1016/j.jnt.2017.01.007},
+}
+
 @article{Ingram2009,
   author = {Patrick Ingram},
   title = {Multiples of Integral Points on Elliptic Curves},


### PR DESCRIPTION
From http://www.sagemath.org/library-publications.html#CiteSage, I believe that the preferred way of indicating that a publication cites sage is to submit a pull request here.

I've added a reference to Hulse, Kuan, Lowry-Duda, and Walker, Sign changes of
coefficients and sums of coefficients of L-functions, Journal of Number Theory, 2017.