### PR TITLE
Fix wrong thesis type of bachelor thesis after compilation.

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -5483,11 +5483,10 @@ note = {https://jacm.scu.ac.ir/article_16704.html},
 
 }
 
-@thesis{Miesch2021,
-  author      = {Miesch, Katharina},
-  institution = {Technische Universität Berlin},
-  date        = {2021},
-  title       = {Gitterangriffe auf RSA mit kleinem privaten Exponenten -- Einfluss der Parameter beim Aufbau der Gittermatrix},
-  type        = {Bachelor’s thesis},
-  note        = {Code is available at https://git.tu-berlin.de/katharina_miesch/bachelor_thesis_code},
+@misc{Miesch2021,
+  author       = {Miesch, Katharina},
+  date         = {2021},
+  howpublished = {Technische Universität Berlin},
+  note         = {Bachelor thesis},
+  title        = {Gitterangriffe auf RSA mit kleinem privaten Exponenten -- Einfluss der Parameter beim Aufbau der Gittermatrix},
 }


### PR DESCRIPTION
After compilation the html-file showed the bachelor thesis as a PhD
thesis. This fixes this issue by changing the corresponding bibtex-entry in "bibliography-sage.bib".