### PR TITLE
add Sage book review in Bulletin AMS

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -3503,6 +3503,17 @@
   volume       = {49},
 }
 
+@article {LittleReview2020,
+  author       = {Little, John B.},
+  date         = {2020},
+  journaltitle = {American Mathematical Society. Bulletin. New Series},
+  volume       = {57},
+  number       = {3},
+  pages        = {515--521},
+  title        = {{\it {C}omputational mathematics with} {\tt {S}age{M}ath} [book review]},
+  note         = {http://dx.doi.org/10.1090/bull/1690},
+}
+
 @article{Lotscher2010,
   author       = {Lötscher, Roland},
   date         = {2010},


### PR DESCRIPTION
This is how it was formatted on MSN, except there was a cross-reference to the actual book, for which see separate pull request - but I don't know how to make a link or if we even want to do that.