### PR TITLE
Add my Master's thesis

### DIFF
--- a/bibliography-sage.bib
+++ b/bibliography-sage.bib
@@ -3680,6 +3680,15 @@
   title        = {Elementary Algebra Related to the SAT Problem},
 }
 
+@mastersthesis{Macri2025,
+  author = {Macri, Vincent},
+  month  = {sep},
+  note   = {https://dx.doi.org/10.11575/PRISM/50422},
+  school = {University of Calgary},
+  title  = {Comparison of and Improvements to Degree Zero Divisor Class Group Arithmetic in Algebraic Function Fields},
+  year   = {2025},
+}
+
 @inproceedings{MaitraSarkar2008A,
   author    = {Maitra, Subhamoy and Sarkar, Santanu},
   editor    = {Tzong-ChenWu and Lei, Chin-Laung and Rijmen, Vincent and Lee, Der-Tsai},


### PR DESCRIPTION
Add my Master's thesis which uses SageMath extensively to the publication list.

Also this is the first use of the `@mastersthesis` entry type in the bib file, which is a standard entry type in bibtex. Currently all the other Master's theses render incorrectly as PhD thesis because they don't use the `@mastersthesis` type, I'll fix this in a follow-up after this merges if nothing breaks (it seems fine locally).